### PR TITLE
chore(renovate): require full version pinning across the org

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":pinAllExceptPeerDependencies"],
+  "extends": ["config:recommended"],
+  "rangeStrategy": "pin",
+  "pinDigests": true,
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "timezone": "Europe/Amsterdam",


### PR DESCRIPTION
Switches the org-wide Renovate config from `:pinAllExceptPeerDependencies` to explicit `rangeStrategy: pin` + `pinDigests: true`.

After this merges, every repo extending `local>seventwo-studio/.github` will have:
- All deps pinned to exact versions (including peerDependencies)
- Action / container digest pins on update

🤖 Generated with [Claude Code](https://claude.com/claude-code)