### PR TITLE
Add Renovate reviewer preset

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "additionalReviewers": ["lucasilverentand"],
+  "assignAutomerge": true
+}


### PR DESCRIPTION
## Summary

- Add an organization Renovate preset that requests `lucasilverentand` as an additional reviewer.
- Set `assignAutomerge` so reviewer assignment still happens when Renovate opens automerge-enabled PRs.

## Validation

- Parsed `renovate-config.json` as JSON locally.
- Replaced the original API-created commit with an SSH-signed commit and verified it with `git verify-commit`.
